### PR TITLE
Math verify

### DIFF
--- a/verl/utils/reward_score/__init__.py
+++ b/verl/utils/reward_score/__init__.py
@@ -59,6 +59,18 @@ def default_compute_score(
         from . import math_dapo
 
         res = math_dapo.compute_score(solution_str, ground_truth)
+    elif data_source == "math_verify":
+        from . import math_verify 
+
+        correct, pred = math_verify.compute_score(solution_str, ground_truth)
+        reward = 1.0 if correct else -1.0
+        acc = correct
+        res = {
+            "score": reward,
+            "acc": acc,
+            "pred": pred,
+        }
+
     elif data_source in [
         "numina_aops_forum",
         "numina_synthetic_math",

--- a/verl/utils/reward_score/__init__.py
+++ b/verl/utils/reward_score/__init__.py
@@ -63,6 +63,16 @@ def default_compute_score(
         from . import math_verify 
 
         correct, pred = math_verify.compute_score(solution_str, ground_truth)
+
+        # ugly: this is needed because math verify produces
+        # predictions in tuples of lists
+        while isinstance(pred, list) or isinstance(pred, tuple):
+            if len(pred) > 0:
+                pred = pred[0]
+            else:
+                pred = None
+                break
+
         reward = 1.0 if correct else -1.0
         acc = correct
         res = {

--- a/verl/utils/reward_score/math_verify.py
+++ b/verl/utils/reward_score/math_verify.py
@@ -30,10 +30,10 @@ def compute_score(model_output: str, ground_truth: str, timeout_score: float = 0
     # Wrap the ground truth in \boxed{} format for verification
     ground_truth_boxed = "\\boxed{" + ground_truth + "}"
     try:
-        ret_score, _ = verify_func([ground_truth_boxed], [model_output])
+        ret_score, preds  = verify_func([ground_truth_boxed], [model_output])
     except Exception:
         pass
     except TimeoutException:
         ret_score = timeout_score
 
-    return ret_score
+    return ret_score, preds


### PR DESCRIPTION
Turns on the `math-verify` score compare.

1.  triggers if `data_source` column in the dataset is `math_verify`.
2. requires `pip install verl[math]` packages.